### PR TITLE
Improved an error message

### DIFF
--- a/qiita-api.js
+++ b/qiita-api.js
@@ -44,7 +44,7 @@ class QiitaAPI {
         })
       }
       else if (response.statusCode >= '400') {
-        vscode.window.showInformationMessage('failed to upload with error ' + response.statusCode)
+        vscode.window.showErrorMessage(`failed to upload with error ${response.statusCode} ${data.message}`)
       }
     })
     console.log("logging reponse ")
@@ -74,7 +74,7 @@ class QiitaAPI {
         vscode.window.showInformationMessage('hooray! successfully uploaded')
       }
       else if (response.statusCode >= '400') {
-        vscode.window.showInformationMessage('failed to upload with error ' + response.statusCode)
+        vscode.window.showErrorMessage(`failed to upload with error ${response.statusCode} ${data.message}`)
       }
     })
   }


### PR DESCRIPTION
# Description
According to [Qiita API reference](https://qiita.com/api/v2/docs#エラーレスポンス), an error response is returned when an error occurs.
> {
>     "message": "Not found",
>     "type": "not_found"
> }

Therefore, I improved to display the error message received.

# fix issues
#4

# Screenshot
![fixederrormessage](https://user-images.githubusercontent.com/11808736/50421000-27508280-087e-11e9-820a-1795e6124da5.PNG)