### PR TITLE
Add shared JSON metadata handler

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,27 @@ const vscode = require('vscode');
 const QiitaAPI = require('./qiita-api')
 const Qiita = new QiitaAPI
 const path = require('path')
+const { parseOptions, stringifyOptions } = require('./json-handler')
+
+function readArticle(editor) {
+    if (!editor) {
+        return;
+    }
+
+    let firstLine = editor.document.lineAt(1);
+    let lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+    let textrange = new vscode.Range(1, firstLine.range.start.character, editor.document.lineCount - 1, lastLine.range.end.character);
+    let body = editor.document.getText(textrange);
+    let title = path.basename(editor.document.fileName);
+    let options = parseOptions(editor.document.lineAt(0).text);
+
+    return { body, title, options };
+}
+
+function showJsonError(error) {
+    vscode.window.showErrorMessage(`invalid Qiita metadata JSON: ${error.message}`)
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 function activate(context) {
@@ -25,19 +46,20 @@ function activate(context) {
         if (!editor)
             return; // No open text editor
 
-        let firstLine = editor.document.lineAt(1);
-        let lastLine = editor.document.lineAt(editor.document.lineCount - 1);
-        let textrange = new vscode.Range(1, firstLine.range.start.character, editor.document.lineCount - 1, lastLine.range.end.character);
-        let body = editor.document.getText(textrange);
-        let title = path.basename(editor.document.fileName);
-        let options = editor.document.getText(new vscode.Range(0, 0, 1, firstLine.range.end.character))
-        console.log(options)
-        if (!title.includes('.md')) {
+        let article
+        try {
+            article = readArticle(editor)
+        } catch (error) {
+            showJsonError(error)
+            return
+        }
+
+        if (!article.title.includes('.md')) {
             vscode.window.showInformationMessage('please save and name your file with a .md extension');
         }
         else {
-            let uploadtitle = title.replace(".md", "")
-            Qiita.post(body, uploadtitle, JSON.parse(options))
+            let uploadtitle = article.title.replace(".md", "")
+            Qiita.post(article.body, uploadtitle, article.options)
         }
 
         //vscode.window.showInformationMessage(text+ ' ' + title);
@@ -46,34 +68,43 @@ function activate(context) {
 
     let createTemplate = vscode.commands.registerCommand('extension.createTemplate', function () {
         let document = vscode.window.activeTextEditor
-        let template = { "id": "", "private": true, "tags": [""],"tweet": false }
-        if (!createTemplate)
+        if (!document)
             return; // No open text editor
         document.edit((builder) => {
             let startPos = document.document.positionAt(0)
-            builder.insert(startPos, JSON.stringify(template) + '\n')
+            builder.insert(startPos, stringifyOptions() + '\n')
         })
     })
 
     let update = vscode.commands.registerCommand('extension.update', function () {
         let article = vscode.window.activeTextEditor
-        let firstLine = article.document.lineAt(1);
-        let lastLine = article.document.lineAt(article.document.lineCount - 1);
-        let textrange = new vscode.Range(1, firstLine.range.start.character, article.document.lineCount - 1, lastLine.range.end.character);
-        let body = article.document.getText(textrange);
-        let title = path.basename(article.document.fileName);
-        let uploadtitle = title.replace(".md", "")
-        let tagline = article.document.lineAt(1);
-        let tags = article.document.getText(new vscode.Range(0, 0, 1, tagline.range.end.character))
-        let options = JSON.parse(tags)
-        Qiita.patch(body, uploadtitle, options)
+        if (!article)
+            return; // No open text editor
+
+        try {
+            article = readArticle(article)
+        } catch (error) {
+            showJsonError(error)
+            return
+        }
+
+        let uploadtitle = article.title.replace(".md", "")
+        Qiita.patch(article.body, uploadtitle, article.options)
     })
 
     let open = vscode.commands.registerCommand('extension.open',function(){
         let article = vscode.window.activeTextEditor
-        let tagline = article.document.lineAt(1);
-        let tags = article.document.getText(new vscode.Range(0, 0, 1, tagline.range.end.character))
-        let options = JSON.parse(tags)
+        if (!article)
+            return; // No open text editor
+
+        let options
+        try {
+            options = parseOptions(article.document.lineAt(0).text)
+        } catch (error) {
+            showJsonError(error)
+            return
+        }
+
         if(!options.id)
             return
         else

--- a/json-handler.js
+++ b/json-handler.js
@@ -1,0 +1,80 @@
+const DEFAULT_OPTIONS = {
+    id: '',
+    private: true,
+    tags: [''],
+    tweet: false,
+};
+
+function normalizeTags(tags) {
+    if (!Array.isArray(tags)) {
+        return [];
+    }
+
+    return tags
+        .map(tag => {
+            if (typeof tag === 'string') {
+                return tag;
+            }
+
+            if (tag && typeof tag.name === 'string') {
+                return tag.name;
+            }
+
+            return '';
+        })
+        .filter(Boolean);
+}
+
+function normalizeOptions(options = {}) {
+    return {
+        id: typeof options.id === 'string' ? options.id : '',
+        private: typeof options.private === 'boolean' ? options.private : DEFAULT_OPTIONS.private,
+        tags: Array.isArray(options.tags) ? normalizeTags(options.tags) : DEFAULT_OPTIONS.tags,
+        tweet: typeof options.tweet === 'boolean' ? options.tweet : DEFAULT_OPTIONS.tweet,
+    };
+}
+
+function parseOptions(json) {
+    const options = JSON.parse(json);
+
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+        throw new TypeError('Qiita metadata must be a JSON object');
+    }
+
+    return normalizeOptions(options);
+}
+
+function stringifyOptions(options = {}) {
+    return JSON.stringify({
+        ...DEFAULT_OPTIONS,
+        ...normalizeOptions(options),
+    });
+}
+
+function toQiitaTags(tags) {
+    return normalizeTags(tags).map(name => ({ name }));
+}
+
+function toQiitaPayload(body, title, options) {
+    const normalizedOptions = normalizeOptions(options);
+
+    return {
+        body,
+        coediting: false,
+        gist: false,
+        group_url_name: 'dev',
+        private: normalizedOptions.private,
+        tags: toQiitaTags(normalizedOptions.tags),
+        title,
+        tweet: normalizedOptions.tweet,
+    };
+}
+
+module.exports = {
+    DEFAULT_OPTIONS,
+    normalizeOptions,
+    parseOptions,
+    stringifyOptions,
+    toQiitaPayload,
+    toQiitaTags,
+};

--- a/qiita-api.js
+++ b/qiita-api.js
@@ -4,6 +4,7 @@ const client = new Client()
 const accessToken = ''
 const baseurl = 'https://qiita.com/api/v2/'
 const settings = require('./qiita.json')
+const { stringifyOptions, toQiitaPayload } = require('./json-handler')
 //const QiitaRequest = require('./api-manager')
 
 class QiitaAPI {
@@ -15,20 +16,8 @@ class QiitaAPI {
   }
 
   post(body, title, options) {
-    let tags = []
-    options.tags.forEach(function (name) { tags.push({ name: name }) })
     let args = {
-      data:
-      {
-        "body": body,
-        "coediting": false,
-        "gist": false,
-        "group_url_name": "dev",
-        "private": options.private,
-        "tags": tags,
-        "title": title,
-        "tweet": options.tweet
-      },
+      data: toQiitaPayload(body, title, options),
       headers: this.headers
     }
     console.log(args)
@@ -37,10 +26,15 @@ class QiitaAPI {
         vscode.window.showInformationMessage('hooray! successfully uploaded')
         let article = vscode.window.activeTextEditor
 
-        let template = { "id": data.id, "private": data.private, "tags": options.tags }
+        let template = {
+          id: data.id,
+          private: data.private,
+          tags: options.tags,
+          tweet: options.tweet
+        }
         article.edit((builder) => {
           // let startPos = article.document.positionAt(0)
-          builder.replace(new vscode.Range(0, 0, 1, 0), JSON.stringify(template) + '\n')
+          builder.replace(new vscode.Range(0, 0, 1, 0), stringifyOptions(template) + '\n')
         })
       }
       else if (response.statusCode >= '400') {
@@ -52,20 +46,8 @@ class QiitaAPI {
   }
 
   patch(body, title, options) {
-    let tags = []
-    options.tags.forEach(function (name) { tags.push({ name: name }) })
     let args = {
-      data:
-      {
-        "body": body,
-        "coediting": false,
-        "gist": false,
-        "group_url_name": "dev",
-        "private": options.private,
-        "tags": tags,
-        "title": title,
-        "tweet": options.tweet
-      },
+      data: toQiitaPayload(body, title, options),
       headers: this.headers
     }
 

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -7,6 +7,12 @@
 
 // The module 'assert' provides assertion methods from node
 const assert = require('assert');
+const {
+    parseOptions,
+    stringifyOptions,
+    toQiitaPayload,
+    toQiitaTags,
+} = require('../json-handler');
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -20,5 +26,50 @@ suite("Extension Tests", function() {
     test("Something 1", function() {
         assert.equal(-1, [1, 2, 3].indexOf(5));
         assert.equal(-1, [1, 2, 3].indexOf(0));
+    });
+
+    test("parseOptions normalizes valid metadata JSON", function() {
+        const options = parseOptions('{"id":"item-id","private":false,"tags":["go","qiita"],"tweet":true}');
+
+        assert.deepEqual(options, {
+            id: 'item-id',
+            private: false,
+            tags: ['go', 'qiita'],
+            tweet: true,
+        });
+    });
+
+    test("stringifyOptions creates default Qiita metadata", function() {
+        assert.equal(
+            stringifyOptions(),
+            '{"id":"","private":true,"tags":[""],"tweet":false}'
+        );
+    });
+
+    test("toQiitaTags converts metadata tags to Qiita API tag objects", function() {
+        assert.deepEqual(toQiitaTags(['go', 'qiita']), [
+            { name: 'go' },
+            { name: 'qiita' },
+        ]);
+    });
+
+    test("toQiitaPayload builds the Qiita item request body", function() {
+        assert.deepEqual(
+            toQiitaPayload('body', 'title', {
+                private: false,
+                tags: ['go'],
+                tweet: true,
+            }),
+            {
+                body: 'body',
+                coediting: false,
+                gist: false,
+                group_url_name: 'dev',
+                private: false,
+                tags: [{ name: 'go' }],
+                title: 'title',
+                tweet: true,
+            }
+        );
     });
 });


### PR DESCRIPTION
## Summary
- add a shared `json-handler` module for Qiita metadata parsing, serialization, tag normalization, and API payload construction
- replace scattered `JSON.parse`, `JSON.stringify`, and tag conversion logic in the extension and Qiita API client
- show a clear error message when the article metadata JSON is invalid
- add unit coverage for the JSON handler helpers

Fixes #3

## Tests
- `node --check json-handler.js && node --check extension.js && node --check qiita-api.js`
- Run json-handler parse/stringify assertions with `node -e`.
- `./node_modules/.bin/mocha test/extension.test.js --ui tdd`
- `git diff --check`

Note: I used `npm install --ignore-scripts --legacy-peer-deps` to avoid launching the deprecated VS Code extension test bootstrap during dependency install.