### PR TITLE
Bundle Qiita JSON handling into helper

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -4,6 +4,7 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 const QiitaAPI = require('./qiita-api')
+const QiitaJson = require('./qiita-json')
 const Qiita = new QiitaAPI
 const path = require('path')
 // this method is called when your extension is activated
@@ -37,7 +38,7 @@ function activate(context) {
         }
         else {
             let uploadtitle = title.replace(".md", "")
-            Qiita.post(body, uploadtitle, JSON.parse(options))
+            Qiita.post(body, uploadtitle, QiitaJson.parseOptions(options))
         }
 
         //vscode.window.showInformationMessage(text+ ' ' + title);
@@ -46,12 +47,12 @@ function activate(context) {
 
     let createTemplate = vscode.commands.registerCommand('extension.createTemplate', function () {
         let document = vscode.window.activeTextEditor
-        let template = { "id": "", "private": true, "tags": [""],"tweet": false }
-        if (!createTemplate)
+        let template = QiitaJson.createTemplate()
+        if (!document)
             return; // No open text editor
         document.edit((builder) => {
             let startPos = document.document.positionAt(0)
-            builder.insert(startPos, JSON.stringify(template) + '\n')
+            builder.insert(startPos, QiitaJson.stringifyOptions(template) + '\n')
         })
     })
 
@@ -65,7 +66,7 @@ function activate(context) {
         let uploadtitle = title.replace(".md", "")
         let tagline = article.document.lineAt(1);
         let tags = article.document.getText(new vscode.Range(0, 0, 1, tagline.range.end.character))
-        let options = JSON.parse(tags)
+        let options = QiitaJson.parseOptions(tags)
         Qiita.patch(body, uploadtitle, options)
     })
 
@@ -73,7 +74,7 @@ function activate(context) {
         let article = vscode.window.activeTextEditor
         let tagline = article.document.lineAt(1);
         let tags = article.document.getText(new vscode.Range(0, 0, 1, tagline.range.end.character))
-        let options = JSON.parse(tags)
+        let options = QiitaJson.parseOptions(tags)
         if(!options.id)
             return
         else

--- a/qiita-api.js
+++ b/qiita-api.js
@@ -4,6 +4,7 @@ const client = new Client()
 const accessToken = ''
 const baseurl = 'https://qiita.com/api/v2/'
 const settings = require('./qiita.json')
+const QiitaJson = require('./qiita-json')
 //const QiitaRequest = require('./api-manager')
 
 class QiitaAPI {
@@ -15,20 +16,8 @@ class QiitaAPI {
   }
 
   post(body, title, options) {
-    let tags = []
-    options.tags.forEach(function (name) { tags.push({ name: name }) })
     let args = {
-      data:
-      {
-        "body": body,
-        "coediting": false,
-        "gist": false,
-        "group_url_name": "dev",
-        "private": options.private,
-        "tags": tags,
-        "title": title,
-        "tweet": options.tweet
-      },
+      data: QiitaJson.createItemData(body, title, options),
       headers: this.headers
     }
     console.log(args)
@@ -37,10 +26,10 @@ class QiitaAPI {
         vscode.window.showInformationMessage('hooray! successfully uploaded')
         let article = vscode.window.activeTextEditor
 
-        let template = { "id": data.id, "private": data.private, "tags": options.tags }
+        let template = QiitaJson.stringifyOptions({ "id": data.id, "private": data.private, "tags": options.tags, "tweet": options.tweet })
         article.edit((builder) => {
           // let startPos = article.document.positionAt(0)
-          builder.replace(new vscode.Range(0, 0, 1, 0), JSON.stringify(template) + '\n')
+          builder.replace(new vscode.Range(0, 0, 1, 0), template + '\n')
         })
       }
       else if (response.statusCode >= '400') {
@@ -52,20 +41,8 @@ class QiitaAPI {
   }
 
   patch(body, title, options) {
-    let tags = []
-    options.tags.forEach(function (name) { tags.push({ name: name }) })
     let args = {
-      data:
-      {
-        "body": body,
-        "coediting": false,
-        "gist": false,
-        "group_url_name": "dev",
-        "private": options.private,
-        "tags": tags,
-        "title": title,
-        "tweet": options.tweet
-      },
+      data: QiitaJson.createItemData(body, title, options),
       headers: this.headers
     }
 

--- a/qiita-json.js
+++ b/qiita-json.js
@@ -1,0 +1,55 @@
+const defaultTemplate = {
+    id: '',
+    private: true,
+    tags: [''],
+    tweet: false
+};
+
+function normalizeOptions(options) {
+    const safeOptions = options || {};
+
+    return {
+        id: safeOptions.id || '',
+        private: typeof safeOptions.private === 'boolean' ? safeOptions.private : true,
+        tags: Array.isArray(safeOptions.tags) ? safeOptions.tags : [],
+        tweet: typeof safeOptions.tweet === 'boolean' ? safeOptions.tweet : false
+    };
+}
+
+function parseOptions(value) {
+    return normalizeOptions(JSON.parse(value));
+}
+
+function stringifyOptions(options) {
+    return JSON.stringify(normalizeOptions(options));
+}
+
+function createTemplate() {
+    return normalizeOptions(defaultTemplate);
+}
+
+function createItemData(body, title, options) {
+    const normalized = normalizeOptions(options);
+    const tags = normalized.tags
+        .filter(name => name)
+        .map(name => ({name: name}));
+
+    return {
+        body: body,
+        coediting: false,
+        gist: false,
+        group_url_name: 'dev',
+        private: normalized.private,
+        tags: tags,
+        title: title,
+        tweet: normalized.tweet
+    };
+}
+
+module.exports = {
+    createItemData: createItemData,
+    createTemplate: createTemplate,
+    normalizeOptions: normalizeOptions,
+    parseOptions: parseOptions,
+    stringifyOptions: stringifyOptions
+};

--- a/test/qiita-json.test.js
+++ b/test/qiita-json.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const QiitaJson = require('../qiita-json');
+
+const options = QiitaJson.parseOptions('{"id":"abc123","private":false,"tags":["go","qiita"],"tweet":true}');
+assert.deepStrictEqual(options, {
+    id: 'abc123',
+    private: false,
+    tags: ['go', 'qiita'],
+    tweet: true
+});
+
+const template = QiitaJson.createTemplate();
+assert.deepStrictEqual(template, {
+    id: '',
+    private: true,
+    tags: [''],
+    tweet: false
+});
+
+const data = QiitaJson.createItemData('# Hello', 'Hello', options);
+assert.deepStrictEqual(data, {
+    body: '# Hello',
+    coediting: false,
+    gist: false,
+    group_url_name: 'dev',
+    private: false,
+    tags: [{name: 'go'}, {name: 'qiita'}],
+    title: 'Hello',
+    tweet: true
+});
+
+assert.strictEqual(
+    QiitaJson.stringifyOptions({tags: ['qiita']}),
+    '{"id":"","private":true,"tags":["qiita"],"tweet":false}'
+);


### PR DESCRIPTION
Fixes #3.

This moves the repeated Qiita metadata/request JSON handling into a small helper module so the extension no longer parses templates and builds request payloads inline in multiple places.

Changes:
- add `qiita-json.js` for parsing, normalizing, stringifying template JSON, and building Qiita item payloads
- use the helper from `extension.js` for post/update/open/template flows
- use the helper from `qiita-api.js` for shared post/patch payload creation
- add a dependency-free regression test for the JSON helper

Verification:
- `node test/qiita-json.test.js`
- `node --check qiita-json.js && node --check qiita-api.js && node --check extension.js`
- `git diff --check`